### PR TITLE
(#1949568) core: allow omitting second part of LoadCredentials= argument

### DIFF
--- a/man/systemd.exec.xml
+++ b/man/systemd.exec.xml
@@ -2821,7 +2821,7 @@ StandardInputData=SWNrIHNpdHplIGRhIHVuJyBlc3NlIEtsb3BzLAp1ZmYgZWVtYWwga2xvcHAncy
     <variablelist class='unit-directives'>
 
       <varlistentry>
-        <term><varname>LoadCredential=</varname><replaceable>ID</replaceable>:<replaceable>PATH</replaceable></term>
+        <term><varname>LoadCredential=</varname><replaceable>ID</replaceable><optional>:<replaceable>PATH</replaceable></optional></term>
 
         <listitem><para>Pass a credential to the unit. Credentials are limited-size binary or textual objects
         that may be passed to unit processes. They are primarily used for passing cryptographic keys (both
@@ -2834,19 +2834,21 @@ StandardInputData=SWNrIHNpdHplIGRhIHVuJyBlc3NlIEtsb3BzLAp1ZmYgZWVtYWwga2xvcHAncy
         environment variable to the unit's processes.</para>
 
         <para>The <varname>LoadCredential=</varname> setting takes a textual ID to use as name for a
-        credential plus a file system path. The ID must be a short ASCII string suitable as filename in the
-        filesystem, and may be chosen freely by the user. If the specified path is absolute it is opened as
-        regular file and the credential data is read from it. If the absolute path refers to an
-        <constant>AF_UNIX</constant> stream socket in the file system a connection is made to it (only once
-        at unit start-up) and the credential data read from the connection, providing an easy IPC integration
-        point for dynamically providing credentials from other services. If the specified path is not
-        absolute and itself qualifies as valid credential identifier it is understood to refer to a
-        credential that the service manager itself received via the <varname>$CREDENTIALS_DIRECTORY</varname>
-        environment variable, which may be used to propagate credentials from an invoking environment (e.g. a
-        container manager that invoked the service manager) into a service. The contents of the file/socket
-        may be arbitrary binary or textual data, including newline characters and <constant>NUL</constant>
-        bytes. This option may be used multiple times, each time defining an additional credential to pass to
-        the unit.</para>
+        credential plus a file system path, separated by a colon. The ID must be a short ASCII string
+        suitable as filename in the filesystem, and may be chosen freely by the user. If the specified path
+        is absolute it is opened as regular file and the credential data is read from it. If the absolute
+        path refers to an <constant>AF_UNIX</constant> stream socket in the file system a connection is made
+        to it (only once at unit start-up) and the credential data read from the connection, providing an
+        easy IPC integration point for dynamically providing credentials from other services. If the
+        specified path is not absolute and itself qualifies as valid credential identifier it is understood
+        to refer to a credential that the service manager itself received via the
+        <varname>$CREDENTIALS_DIRECTORY</varname> environment variable, which may be used to propagate
+        credentials from an invoking environment (e.g. a container manager that invoked the service manager)
+        into a service. The contents of the file/socket may be arbitrary binary or textual data, including
+        newline characters and <constant>NUL</constant> bytes. If the file system path is omitted it is
+        chosen identical to the credential name, i.e. this is a terse way do declare credentials to inherit
+        from the service manager into a service. This option may be used multiple times, each time defining
+        an additional credential to pass to the unit.</para>
 
         <para>The credential files/IPC sockets must be accessible to the service manager, but don't have to
         be directly accessible to the unit's processes: the credential data is read and copied into separate,

--- a/src/core/load-fragment.c
+++ b/src/core/load-fragment.c
@@ -4606,14 +4606,23 @@ int config_parse_load_credential(
                 log_syntax(unit, LOG_WARNING, filename, line, 0, "Credential name \"%s\" not valid, ignoring.", k);
                 return 0;
         }
-        r = unit_full_printf(u, p, &q);
-        if (r < 0) {
-                log_syntax(unit, LOG_WARNING, filename, line, r, "Failed to resolve unit specifiers in \"%s\", ignoring: %m", p);
-                return 0;
-        }
-        if (path_is_absolute(q) ? !path_is_normalized(q) : !credential_name_valid(q)) {
-                log_syntax(unit, LOG_WARNING, filename, line, r, "Credential source \"%s\" not valid, ignoring.", q);
-                return 0;
+
+        if (isempty(p)) {
+                /* If only one field field is specified take it as shortcut for inheriting a credential named
+                 * the same way from our parent */
+                q = strdup(k);
+                if (!q)
+                        return log_oom();
+        } else {
+                r = unit_full_printf(u, p, &q);
+                if (r < 0) {
+                        log_syntax(unit, LOG_WARNING, filename, line, r, "Failed to resolve unit specifiers in \"%s\", ignoring: %m", p);
+                        return 0;
+                }
+                if (path_is_absolute(q) ? !path_is_normalized(q) : !credential_name_valid(q)) {
+                        log_syntax(unit, LOG_WARNING, filename, line, r, "Credential source \"%s\" not valid, ignoring.", q);
+                        return 0;
+                }
         }
 
         r = strv_consume_pair(&context->load_credentials, TAKE_PTR(k), TAKE_PTR(q));


### PR DESCRIPTION
This allows "LoadCredentials=foo" to be used as shortcut for
"LoadCredentials=foo:foo", i.e. it's a very short way to inherit a
credential under its original name from the service manager into a
service.

(cherry picked from commit 8a29862e32fc7981fe16fc8dd79ad6863a8dc486)

Resolves: #1949568