### PR TITLE
(#1931710) rfkill: add some casts to silence -Werror=sign-compare

### DIFF
--- a/src/rfkill/rfkill.c
+++ b/src/rfkill/rfkill.c
@@ -177,7 +177,7 @@ static int load_state(Context *c, const struct rfkill_event *event) {
         ssize_t l = write(c->rfkill_fd, &we, sizeof we);
         if (l < 0)
                 return log_error_errno(errno, "Failed to restore rfkill state for %i: %m", event->idx);
-        if (l < RFKILL_EVENT_SIZE_V1)
+        if ((size_t)l < RFKILL_EVENT_SIZE_V1) /* l cannot be < 0 here. Cast to fix -Werror=sign-compare */
                 return log_error_errno(SYNTHETIC_ERRNO(EIO),
                                        "Couldn't write rfkill event structure, too short (wrote %zd of %zu bytes).",
                                        l, sizeof we);
@@ -335,9 +335,9 @@ static int run(int argc, char *argv[]) {
                         break;
                 }
 
-                if (l < RFKILL_EVENT_SIZE_V1)
-                        return log_error_errno(SYNTHETIC_ERRNO(EIO), "Short read of struct rfkill_event: (%zd < %d)",
-                                               l, RFKILL_EVENT_SIZE_V1);
+                if ((size_t)l < RFKILL_EVENT_SIZE_V1) /* l cannot be < 0 here. Cast to fix -Werror=sign-compare */
+                        return log_error_errno(SYNTHETIC_ERRNO(EIO), "Short read of struct rfkill_event: (%zd < %zu)",
+                                               l, (size_t) RFKILL_EVENT_SIZE_V1); /* Casting necessary to make compiling with different kernel versions happy */
                 log_debug("Reading struct rfkill_event: got %zd bytes.", l);
 
                 /* The event structure has more fields. We only care about the first few, so it's OK if we

--- a/src/rfkill/rfkill.c
+++ b/src/rfkill/rfkill.c
@@ -177,7 +177,7 @@ static int load_state(Context *c, const struct rfkill_event *event) {
         ssize_t l = write(c->rfkill_fd, &we, sizeof we);
         if (l < 0)
                 return log_error_errno(errno, "Failed to restore rfkill state for %i: %m", event->idx);
-        if ((size_t) l < RFKILL_EVENT_SIZE_V1)
+        if (l < RFKILL_EVENT_SIZE_V1)
                 return log_error_errno(SYNTHETIC_ERRNO(EIO),
                                        "Couldn't write rfkill event structure, too short (wrote %zd of %zu bytes).",
                                        l, sizeof we);
@@ -335,7 +335,7 @@ static int run(int argc, char *argv[]) {
                         break;
                 }
 
-                if ((size_t) l < RFKILL_EVENT_SIZE_V1)
+                if (l < RFKILL_EVENT_SIZE_V1)
                         return log_error_errno(SYNTHETIC_ERRNO(EIO), "Short read of struct rfkill_event: (%zd < %d)",
                                                l, RFKILL_EVENT_SIZE_V1);
                 log_debug("Reading struct rfkill_event: got %zd bytes.", l);

--- a/src/rfkill/rfkill.c
+++ b/src/rfkill/rfkill.c
@@ -336,7 +336,7 @@ static int run(int argc, char *argv[]) {
                 }
 
                 if ((size_t) l < RFKILL_EVENT_SIZE_V1)
-                        return log_error_errno(SYNTHETIC_ERRNO(EIO), "Short read of struct rfkill_event: (%zd < %lu)",
+                        return log_error_errno(SYNTHETIC_ERRNO(EIO), "Short read of struct rfkill_event: (%zd < %d)",
                                                l, RFKILL_EVENT_SIZE_V1);
                 log_debug("Reading struct rfkill_event: got %zd bytes.", l);
 


### PR DESCRIPTION
Backport of the "correct" fix from upstream, since the fix from #6 wasn't complete and the build kept failing with:

```
In file included from ../src/basic/macro.h:491,
                 from ../src/basic/alloc-util.h:9,
                 from ../src/rfkill/rfkill.c:13:
../src/rfkill/rfkill.c: In function ‘run’:
../src/rfkill/rfkill.c:339:70: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 8 has type ‘int’ [-Werror=format=]
                         return log_error_errno(SYNTHETIC_ERRNO(EIO), "Short read of struct rfkill_event: (%zd < %lu)",
                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/basic/log.h:195:86: note: in definition of macro ‘log_full_errno’
                         ? log_internal(_level, _e, PROJECT_FILE, __LINE__, __func__, __VA_ARGS__) \
                                                                                      ^~~~~~~~~~~
../src/rfkill/rfkill.c:339:32: note: in expansion of macro ‘log_error_errno’
                         return log_error_errno(SYNTHETIC_ERRNO(EIO), "Short read of struct rfkill_event: (%zd < %lu)",
                                ^~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

/cc @dtardon @msekletar 